### PR TITLE
use non-volatile variables for baud calculation

### DIFF
--- a/include/debug.c
+++ b/include/debug.c
@@ -161,8 +161,8 @@ void CH554UART0Alter()
 *******************************************************************************/
 void	mInitSTDIO( )
 {
-    volatile uint32_t x;
-    volatile uint8_t x2;
+    uint32_t x;
+    uint8_t x2;
 
     SM0 = 0;
     SM1 = 1;


### PR DESCRIPTION
Fixes issue #19 