### PR TITLE
conditionally compile USB CDC debug code

### DIFF
--- a/examples/usb_device_cdc/main.c
+++ b/examples/usb_device_cdc/main.c
@@ -579,7 +579,9 @@ main()
                 USBByteCount--;
 
                 if(USBByteCount==0)
+#ifdef DEBUG
                     dataRecievedCopFlag = 1;
+#endif
                     UEP2_CTRL = UEP2_CTRL & ~ MASK_UEP_R_RES | UEP_R_RES_ACK;
 
             }
@@ -609,7 +611,7 @@ main()
                 }
             }
         }
-
+#ifdef DEBUG
     if(dataRecievedCopFlag){
         CH554UART1SendByte((char)'H');
         if (strcmp((const signed char*)recievedData, (const signed char*)'OK\n') == 1)
@@ -622,6 +624,6 @@ main()
 
 
     }
-
+#endif                                  // DEBUG
     }
 }


### PR DESCRIPTION
When reviewing the the example, I noticed what looks like debug code.
https://github.com/Blinkinlabs/ch554_sdcc/blob/master/examples/usb_device_cdc/main.c#L613

I tested with a ch552 using a loopback resistor between TXD1 and RXD1 (P1.7/P1.6), and received an extra 'H' character for every character I typed.  Instead of removing the debug code, I changed it to compile only when DEBUG is defined.
