### PR TITLE
change db and hex number to sdcc format

### DIFF
--- a/include/ch554.h
+++ b/include/ch554.h
@@ -745,7 +745,7 @@ ASM example:
        MOV  R7,#xxH
  LOOP: MOVX A,@DPTR ;DPTR0
        INC  DPTR    ;DPTR0, if need
-       DB   0A5H    ;MOVX @DPTR1,A & INC DPTR1
+       .DB  0xA5    ;MOVX @DPTR1,A & INC DPTR1
        DJNZ R7,LOOP
 */
 


### PR DESCRIPTION
The SDCC assembler's syntax is a little different to Keil's. The proposed change has been tested in inline assembler.

Referring to http://svn.code.sf.net/p/sdcc/code/trunk/sdcc/sdas/doc/asmlnk.txt
```
$$,   0h, 0H, 0x, 0X    Hexadecimal radix operator.

                .byte   exp             ;Stores the binary value
                .db     exp             ;of the expression in the
                .fcb    exp             ;next byte.
```