### PR TITLE
Fix ADC_CFG in ADCInit() and correct comments.

### DIFF
--- a/include/adc.c
+++ b/include/adc.c
@@ -20,14 +20,14 @@
 * Function Name  : ADCInit(uint8_t div)
 * Description    : ADC sampling clock setting, module is turned on, interrupt is turned on
 * Input          : uint8_t speed clock setting
-                   1 Slow 384 Fosc                   								
-                   0 Fast 96 Fosc									 
+                   0 Slow 384 Fosc
+                   1 Fast  96 Fosc
 * Output         : None
 * Return         : None
 *******************************************************************************/
 void ADCInit(uint8_t speed)
 {
-    ADC_CFG &= ~bADC_CLK | speed;
+    ADC_CFG = (ADC_CFG & ~bADC_CLK) | speed;
     ADC_CFG |= bADC_EN;                                                        //ADC power enable
 #if ADC_INTERRUPT
     ADC_IF = 0;                                                                //Clear interrupt


### PR DESCRIPTION
Fix #46.

1. Correct the ADC_CFG set statement in ADCInit().

```c
ADC_CFG = (ADC_CFG & ~bADC_CLK) | speed;
```

2. Fix the comment according to CH554 datasheet.

> ADC reference clock frequency selection bit
> 0: Slow clock. 384 Fosc cycles required for each ADC;
> 1: Fast clock. 96 Fosc cycles required for each ADC